### PR TITLE
injecting prisma dependency

### DIFF
--- a/dependency_injection/DIContainerNextApiRequest.ts
+++ b/dependency_injection/DIContainerNextApiRequest.ts
@@ -1,0 +1,6 @@
+import { NextApiRequest } from "next";
+import { AwilixContainer } from "awilix";
+
+export interface DIContainerNextApiRequest extends NextApiRequest {
+  scope: AwilixContainer<any>;
+}

--- a/dependency_injection/createDIContainer.ts
+++ b/dependency_injection/createDIContainer.ts
@@ -1,0 +1,31 @@
+import { createContainer, asFunction } from "awilix";
+import { PrismaClient } from "@prisma/client";
+import pagarme from "pagarme";
+
+async function createDIContainer() {
+  const container = createContainer();
+
+  container.register({
+    dbClient: asFunction(createPrismaClient)
+      .scoped()
+      .disposer((client) => {
+        client.disconnect();
+      }),
+    pagarmeClient: asFunction(createPagarmeClient).singleton(),
+  });
+
+  return container;
+}
+
+function createPrismaClient(): PrismaClient {
+  return new PrismaClient();
+}
+
+async function createPagarmeClient() {
+  const pagarmeClient = await pagarme.client.connect({
+    api_key: process.env.PAGARME_API_KEY,
+  });
+  return pagarmeClient;
+}
+
+export default createDIContainer;

--- a/middlewares/diContainerMiddleware.ts
+++ b/middlewares/diContainerMiddleware.ts
@@ -1,16 +1,18 @@
 import { NextApiRequest, NextApiResponse } from "next";
+import { DIContainerNextApiRequest } from "../dependency_injection/DIContainerNextApiRequest";
 import createDIContainer from "../dependency_injection/createDIContainer";
 
 async function runRequestWithDIContainer(
   req: NextApiRequest,
   res: NextApiResponse,
-  func: (req: NextApiRequest, res: NextApiResponse) => Promise<void>
+  func: (req: DIContainerNextApiRequest, res: NextApiResponse) => Promise<void>
 ) {
   const container = await createDIContainer();
   const scope = container.createScope();
-  req.scope = scope;
+  const diReq = req as DIContainerNextApiRequest;
+  diReq.scope = scope;
   try {
-    await func(req, res);
+    await func(diReq, res);
   } finally {
     scope.dispose();
   }

--- a/middlewares/diContainerMiddleware.ts
+++ b/middlewares/diContainerMiddleware.ts
@@ -1,0 +1,19 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import createDIContainer from "../dependency_injection/createDIContainer";
+
+async function runRequestWithDIContainer(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  func: (req: NextApiRequest, res: NextApiResponse) => Promise<void>
+) {
+  const container = await createDIContainer();
+  const scope = container.createScope();
+  req.scope = scope;
+  try {
+    await func(req, res);
+  } finally {
+    scope.dispose();
+  }
+}
+
+export default runRequestWithDIContainer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5599,6 +5599,15 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "awilix": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/awilix/-/awilix-4.2.6.tgz",
+      "integrity": "sha512-28avOdjml+yvy4iDFhsC+r7Z5ImR0MM5NNjgVvNbr6bQXv6uwXGS9cMbvUn/pEWNPh+sv88/pyJSvWlBIXXpuw==",
+      "requires": {
+        "camel-case": "^4.1.1",
+        "glob": "^7.1.6"
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -6142,6 +6151,15 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
+    },
+    "camel-case": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+      "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+      "requires": {
+        "pascal-case": "^3.1.1",
+        "tslib": "^1.10.0"
+      }
     },
     "camelcase": {
       "version": "5.3.1",
@@ -9853,6 +9871,14 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lower-case": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+      "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+      "requires": {
+        "tslib": "^1.10.0"
+      }
+    },
     "lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -10409,6 +10435,15 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "no-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+      "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+      "requires": {
+        "lower-case": "^2.0.1",
+        "tslib": "^1.10.0"
+      }
+    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -10846,6 +10881,15 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
       "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
       "dev": true
+    },
+    "pascal-case": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
+      "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
+      "requires": {
+        "no-case": "^3.0.3",
+        "tslib": "^1.10.0"
+      }
     },
     "pascalcase": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@prisma/cli": "^2.1.3",
     "@prisma/client": "^2.1.3",
+    "awilix": "^4.2.6",
     "axios": "^0.19.2",
     "computed-types": "^1.1.0",
     "next": "^9.4.4",

--- a/pages/api/contributions/index.ts
+++ b/pages/api/contributions/index.ts
@@ -5,6 +5,7 @@ import axios from "axios";
 import url from "url";
 import runRequestWithDIContainer from "../../../middlewares/diContainerMiddleware";
 import { PrismaClient } from "@prisma/client";
+import { DIContainerNextApiRequest } from "../../../dependency_injection/DIContainerNextApiRequest";
 
 const herokuAppName = process.env.HEROKU_APP_NAME || `reditus-staging`;
 const publicUrl =
@@ -47,7 +48,7 @@ const CreateContributionSchema = schema({
 });
 
 async function runCreateContribution(
-  req: NextApiRequest,
+  req: DIContainerNextApiRequest,
   res: NextApiResponse
 ) {
   const prismaClient: PrismaClient = req.scope.resolve("dbClient");

--- a/pages/api/contributions/index.ts
+++ b/pages/api/contributions/index.ts
@@ -3,6 +3,8 @@ import schema, { string, number } from "computed-types";
 import createContribution from "../../../use_cases/createContribution";
 import axios from "axios";
 import url from "url";
+import runRequestWithDIContainer from "../../../middlewares/diContainerMiddleware";
+import { PrismaClient } from "@prisma/client";
 
 const herokuAppName = process.env.HEROKU_APP_NAME || `reditus-staging`;
 const publicUrl =
@@ -48,10 +50,13 @@ async function runCreateContribution(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
+  const prismaClient: PrismaClient = req.scope.resolve("dbClient");
+
   const validator = CreateContributionSchema.destruct();
   const [err, args] = validator(req.body);
   if (!err && args) {
     const contribution = await createContribution({
+      dbClient: prismaClient,
       email: args.customer.email,
       amountInCents: args.amount,
     });
@@ -129,7 +134,7 @@ async function runCreateContribution(
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method === "POST") {
-    await runCreateContribution(req, res);
+    await runRequestWithDIContainer(req, res, runCreateContribution);
   } else {
     res.statusCode = 405;
     res.send("");

--- a/pages/api/pagarme/postback.ts
+++ b/pages/api/pagarme/postback.ts
@@ -17,6 +17,7 @@ import {
 } from "../../../pagarme_integration/pagarmeSubscriptionStatus";
 import runRequestWithDIContainer from "../../../middlewares/diContainerMiddleware";
 import { PrismaClient } from "@prisma/client";
+import { DIContainerNextApiRequest } from "../../../dependency_injection/DIContainerNextApiRequest";
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method === "POST") {
@@ -27,7 +28,10 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   }
 };
 
-async function runProcessPostback(req: NextApiRequest, res: NextApiResponse) {
+async function runProcessPostback(
+  req: DIContainerNextApiRequest,
+  res: NextApiResponse
+) {
   const signature = getFirstHeader(req, "x-hub-signature");
 
   const validPostBack = await validatePagarmePostback({

--- a/pages/api/pagarme/postback.ts
+++ b/pages/api/pagarme/postback.ts
@@ -15,46 +15,54 @@ import {
   isCompletableStatus as isCompletableSubscriptionStatus,
   isCancelableStatus as isCancelableSubscriptionStatus,
 } from "../../../pagarme_integration/pagarmeSubscriptionStatus";
+import runRequestWithDIContainer from "../../../middlewares/diContainerMiddleware";
+import { PrismaClient } from "@prisma/client";
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method === "POST") {
-    const signature = getFirstHeader(req, "x-hub-signature");
-
-    const validPostBack = await validatePagarmePostback({
-      requestBodyText: stringify(req.body),
-      requestSignatureHeader: signature ?? "",
-    });
-
-    if (validPostBack) {
-      const postbackObjectType = req.body["object"];
-      if (postbackObjectType === "transaction") {
-        const referenceKey = req.body["transaction[reference_key]"];
-        const referenceId = referenceKey.split(":")[1];
-        await runProcessTransactionPostback(req, res, +referenceId);
-      } else if (postbackObjectType === "subscription") {
-        const referenceKey =
-          req.body["subscription[current_transaction][reference_key]"]; // can be an empty string
-        let referenceId = 0;
-        if (referenceKey) {
-          referenceId = +referenceKey.split(":")[1];
-        }
-
-        await runProcessSubscriptionPostback(req, res, referenceId);
-      }
-    } else {
-      res.statusCode = 400;
-      res.send("Invalid postback signature");
-    }
+    await runRequestWithDIContainer(req, res, runProcessPostback);
   } else {
     res.statusCode = 405;
     res.send("");
   }
 };
 
+async function runProcessPostback(req: NextApiRequest, res: NextApiResponse) {
+  const signature = getFirstHeader(req, "x-hub-signature");
+
+  const validPostBack = await validatePagarmePostback({
+    requestBodyText: stringify(req.body),
+    requestSignatureHeader: signature ?? "",
+  });
+
+  if (validPostBack) {
+    const prismaClient: PrismaClient = req.scope.resolve("dbClient");
+    const postbackObjectType = req.body["object"];
+    if (postbackObjectType === "transaction") {
+      const referenceKey = req.body["transaction[reference_key]"];
+      const referenceId = referenceKey.split(":")[1];
+      await runProcessTransactionPostback(req, res, +referenceId, prismaClient);
+    } else if (postbackObjectType === "subscription") {
+      const referenceKey =
+        req.body["subscription[current_transaction][reference_key]"]; // can be an empty string
+      let referenceId = 0;
+      if (referenceKey) {
+        referenceId = +referenceKey.split(":")[1];
+      }
+
+      await runProcessSubscriptionPostback(req, res, referenceId, prismaClient);
+    }
+  } else {
+    res.statusCode = 400;
+    res.send("Invalid postback signature");
+  }
+}
+
 async function runProcessTransactionPostback(
   req: NextApiRequest,
   res: NextApiResponse,
-  contributionId: number
+  contributionId: number,
+  dbClient: PrismaClient
 ) {
   res.statusCode = 200;
 
@@ -69,12 +77,16 @@ async function runProcessTransactionPostback(
   const pagarmeId = req.body["transaction[id]"];
   if (await isCompletableTransactionStatus(newPagarmeStatus)) {
     const result = await completeContribution({
+      dbClient: dbClient,
       contributionId: contributionId,
       externalId: `pagarme:${pagarmeId}`,
     });
     res.json(result);
   } else if (await isCancelableTransactionStatus(newPagarmeStatus)) {
-    const result = await cancelContribution({ contributionId: contributionId });
+    const result = await cancelContribution({
+      dbClient: dbClient,
+      contributionId: contributionId,
+    });
     res.json(result);
   } else {
     // do nothing
@@ -85,7 +97,8 @@ async function runProcessTransactionPostback(
 async function runProcessSubscriptionPostback(
   req: NextApiRequest,
   res: NextApiResponse,
-  subscriptionId: number
+  subscriptionId: number,
+  dbClient: PrismaClient
 ) {
   res.statusCode = 200;
 
@@ -101,6 +114,7 @@ async function runProcessSubscriptionPostback(
   // we can try to retrieve the subscription id if we have the corresponding external id already in our database
   if (subscriptionId === 0) {
     const subscription = await getSubscriptionByExternalId({
+      dbClient: dbClient,
       externalId: externalPagarmeSubscriptionId,
     });
 
@@ -114,6 +128,7 @@ async function runProcessSubscriptionPostback(
     const newPagarmeStatus = req.body["current_status"];
     if (await isCompletableSubscriptionStatus(newPagarmeStatus)) {
       const result = await completeSubscription({
+        dbClient: dbClient,
         subscriptionId: subscriptionId,
         externalId: externalPagarmeSubscriptionId,
         externalContributionId: externalPagarmeContributionId,
@@ -121,6 +136,7 @@ async function runProcessSubscriptionPostback(
       res.json(result);
     } else if (await isCancelableSubscriptionStatus(newPagarmeStatus)) {
       const result = await cancelSubscription({
+        dbClient: dbClient,
         subscriptionId: subscriptionId,
       });
       res.json(result);
@@ -130,6 +146,7 @@ async function runProcessSubscriptionPostback(
     }
   } else if (event === "transaction_created") {
     const result = await createContribution({
+      dbClient: dbClient,
       amountInCents: +req.body["subscription[current_transaction][amount]"],
       subscriptionId: subscriptionId,
       externalContributionId: externalPagarmeContributionId,

--- a/pages/api/subscriptions/index.ts
+++ b/pages/api/subscriptions/index.ts
@@ -10,6 +10,7 @@ import {
 import url from "url";
 import runRequestWithDIContainer from "../../../middlewares/diContainerMiddleware";
 import { PrismaClient } from "@prisma/client";
+import { DIContainerNextApiRequest } from "../../../dependency_injection/DIContainerNextApiRequest";
 
 const herokuAppName = process.env.HEROKU_APP_NAME || `reditus-staging`;
 const publicUrl =
@@ -61,14 +62,14 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 };
 
 async function runCreateSubscription(
-  req: NextApiRequest,
+  req: DIContainerNextApiRequest,
   res: NextApiResponse
 ) {
   const validator = CreateSubscriptionSchema.destruct();
   const [err, args] = validator(req.body);
   if (!err && args) {
     const prismaClient: PrismaClient = req.scope.resolve("dbClient");
-    const pagarmeClient = await req.scope.resolve("pagarmeClient");
+    const pagarmeClient: any = await req.scope.resolve("pagarmeClient");
 
     let subscription = await createSubscription({
       dbClient: prismaClient,

--- a/pages/api/subscriptions/index.ts
+++ b/pages/api/subscriptions/index.ts
@@ -7,8 +7,9 @@ import {
   isCompletableStatus,
   isCancelableStatus,
 } from "../../../pagarme_integration/pagarmeSubscriptionStatus";
-import pagarme from "pagarme";
 import url from "url";
+import runRequestWithDIContainer from "../../../middlewares/diContainerMiddleware";
+import { PrismaClient } from "@prisma/client";
 
 const herokuAppName = process.env.HEROKU_APP_NAME || `reditus-staging`;
 const publicUrl =
@@ -52,7 +53,7 @@ const CreateSubscriptionSchema = schema({
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method === "POST") {
-    await runCreateSubscription(req, res);
+    await runRequestWithDIContainer(req, res, runCreateSubscription);
   } else {
     res.statusCode = 405;
     res.send("");
@@ -66,7 +67,11 @@ async function runCreateSubscription(
   const validator = CreateSubscriptionSchema.destruct();
   const [err, args] = validator(req.body);
   if (!err && args) {
+    const prismaClient: PrismaClient = req.scope.resolve("dbClient");
+    const pagarmeClient = await req.scope.resolve("pagarmeClient");
+
     let subscription = await createSubscription({
+      dbClient: prismaClient,
       email: args.customer.email,
       amountInCents: args.amount,
     });
@@ -74,9 +79,6 @@ async function runCreateSubscription(
     const billingPeriodString = process.env.SUBSCRIPTION_BILLING_PERIOD || "30";
     const billingPeriod = +billingPeriodString;
 
-    const pagarmeClient = await pagarme.client.connect({
-      api_key: process.env.PAGARME_API_KEY,
-    });
     const pagarmePlan = await pagarmeClient.plans.create({
       amount: args.amount,
       days: billingPeriod,
@@ -99,12 +101,14 @@ async function runCreateSubscription(
 
     if (isCompletableStatus(pagarmeSubscription.status)) {
       subscription = await completeSubscription({
+        dbClient: prismaClient,
         subscriptionId: subscription.id,
         externalId: `pagarme:${pagarmeSubscription.id}`,
         externalContributionId: `pagarme:${pagarmeSubscription.current_transaction.id}`,
       });
     } else if (isCancelableStatus(pagarmeSubscription.status)) {
       subscription = await cancelSubscription({
+        dbClient: prismaClient,
         subscriptionId: subscription.id,
       });
     }

--- a/use_cases/cancelContribution.test.ts
+++ b/use_cases/cancelContribution.test.ts
@@ -14,6 +14,7 @@ afterAll(async () => {
 
 test("creates a contribution in the database, cancels it and returns it", async () => {
   const resultCreate = await createContribution({
+    dbClient: prisma,
     email: "email3@example.com",
     amountInCents: 300,
   });
@@ -29,6 +30,7 @@ test("creates a contribution in the database, cancels it and returns it", async 
   ).toEqual(resultCreate);
 
   const resultCancel = await cancelContribution({
+    dbClient: prisma,
     contributionId: resultCreate.id,
   });
 
@@ -40,16 +42,16 @@ test("creates a contribution in the database, cancels it and returns it", async 
 });
 
 test("throws error if contribution id is invalid", async () => {
-  await expect(cancelContribution({ contributionId: -1 })).rejects.toThrow(
-    "Invalid id"
-  );
+  await expect(
+    cancelContribution({ dbClient: prisma, contributionId: -1 })
+  ).rejects.toThrow("Invalid id");
 });
 
 test("throws error if id does not exist", async () => {
   const id = 99999999;
-  await expect(cancelContribution({ contributionId: id })).rejects.toThrow(
-    `Id ${id} not found`
-  );
+  await expect(
+    cancelContribution({ dbClient: prisma, contributionId: id })
+  ).rejects.toThrow(`Id ${id} not found`);
 });
 
 export {};

--- a/use_cases/cancelContribution.ts
+++ b/use_cases/cancelContribution.ts
@@ -1,7 +1,8 @@
-import { Contribution } from "@prisma/client";
+import { Contribution, PrismaClient } from "@prisma/client";
 import changeContributionState from "./changeContributionState";
 
 interface CancelContributionArgs {
+  dbClient: PrismaClient;
   contributionId: number;
 }
 
@@ -9,6 +10,7 @@ const cancelContribution = async (
   args: CancelContributionArgs
 ): Promise<Contribution> => {
   return await changeContributionState({
+    dbClient: args.dbClient,
     contributionId: args.contributionId,
     state: "cancelled",
   });

--- a/use_cases/cancelSubscription.test.ts
+++ b/use_cases/cancelSubscription.test.ts
@@ -14,6 +14,7 @@ afterAll(async () => {
 
 test("creates a subscription in the database, cancels it and returns it", async () => {
   const resultCreate = await createSubscription({
+    dbClient: prisma,
     email: "emailSubCanc@example.com",
     amountInCents: 601,
   });
@@ -31,6 +32,7 @@ test("creates a subscription in the database, cancels it and returns it", async 
   ).toEqual(resultCreate);
 
   const resultCancel = await cancelSubscription({
+    dbClient: prisma,
     subscriptionId: resultCreate.id,
   });
 
@@ -45,16 +47,16 @@ test("creates a subscription in the database, cancels it and returns it", async 
 });
 
 test("throws error if contribution id is invalid (cancel)", async () => {
-  await expect(cancelSubscription({ subscriptionId: -1 })).rejects.toThrow(
-    "Invalid id"
-  );
+  await expect(
+    cancelSubscription({ dbClient: prisma, subscriptionId: -1 })
+  ).rejects.toThrow("Invalid id");
 });
 
 test("throws error if id does not exist (cancel)", async () => {
   const id = 99999999;
-  await expect(cancelSubscription({ subscriptionId: id })).rejects.toThrow(
-    `Id ${id} not found`
-  );
+  await expect(
+    cancelSubscription({ dbClient: prisma, subscriptionId: id })
+  ).rejects.toThrow(`Id ${id} not found`);
 });
 
 export {};

--- a/use_cases/cancelSubscription.ts
+++ b/use_cases/cancelSubscription.ts
@@ -1,6 +1,7 @@
 import { ContributionSubscription, PrismaClient } from "@prisma/client";
 
 interface CancelSubscriptionArgs {
+  dbClient: PrismaClient;
   subscriptionId: number;
 }
 
@@ -9,7 +10,7 @@ const cancelSubscription = async (
 ): Promise<ContributionSubscription> => {
   if (args.subscriptionId <= 0) throw new Error("Invalid id");
 
-  const prisma = new PrismaClient();
+  const prisma = args.dbClient;
 
   const subscription = await prisma.contributionSubscription.findOne({
     where: {

--- a/use_cases/changeContributionState.ts
+++ b/use_cases/changeContributionState.ts
@@ -1,6 +1,7 @@
 import { Contribution, ContributionState, PrismaClient } from "@prisma/client";
 
 interface ChangeContributionStateArgs {
+  dbClient: PrismaClient;
   contributionId: number;
   state: ContributionState;
   externalId?: string;
@@ -11,9 +12,7 @@ const changeContributionState = async (
 ): Promise<Contribution> => {
   if (args.contributionId <= 0) throw new Error("Invalid id");
 
-  const prisma = new PrismaClient();
-
-  const contribution = await prisma.contribution.findOne({
+  const contribution = await args.dbClient.contribution.findOne({
     where: {
       id: args.contributionId,
     },
@@ -23,7 +22,7 @@ const changeContributionState = async (
     throw new Error(`Id ${args.contributionId} not found`);
 
   if (args.externalId) {
-    return await prisma.contribution.update({
+    return await args.dbClient.contribution.update({
       where: {
         id: args.contributionId,
       },
@@ -33,7 +32,7 @@ const changeContributionState = async (
       },
     });
   } else {
-    return await prisma.contribution.update({
+    return await args.dbClient.contribution.update({
       where: {
         id: args.contributionId,
       },

--- a/use_cases/completeContribution.test.ts
+++ b/use_cases/completeContribution.test.ts
@@ -14,6 +14,7 @@ afterAll(async () => {
 
 test("creates a contribution in the database, completes it and returns it", async () => {
   const resultCreate = await createContribution({
+    dbClient: prisma,
     email: "email2@example.com",
     amountInCents: 200,
   });
@@ -30,6 +31,7 @@ test("creates a contribution in the database, completes it and returns it", asyn
   expect(resultCreate.externalId).toBeNull();
 
   const resultComplete = await completeContribution({
+    dbClient: prisma,
     contributionId: resultCreate.id,
     externalId: "123",
   });
@@ -44,14 +46,22 @@ test("creates a contribution in the database, completes it and returns it", asyn
 
 test("throws error if contribution id is invalid", async () => {
   await expect(
-    completeContribution({ contributionId: -1, externalId: "123" })
+    completeContribution({
+      dbClient: prisma,
+      contributionId: -1,
+      externalId: "123",
+    })
   ).rejects.toThrow("Invalid id");
 });
 
 test("throws error if id does not exist", async () => {
   const id = 99999999;
   await expect(
-    completeContribution({ contributionId: id, externalId: "123" })
+    completeContribution({
+      dbClient: prisma,
+      contributionId: id,
+      externalId: "123",
+    })
   ).rejects.toThrow(`Id ${id} not found`);
 });
 

--- a/use_cases/completeContribution.ts
+++ b/use_cases/completeContribution.ts
@@ -1,7 +1,8 @@
-import { Contribution } from "@prisma/client";
+import { Contribution, PrismaClient } from "@prisma/client";
 import changeContributionState from "./changeContributionState";
 
 interface CompleteContributionArgs {
+  dbClient: PrismaClient;
   contributionId: number;
   externalId: string;
 }
@@ -10,6 +11,7 @@ const completeContribution = async (
   args: CompleteContributionArgs
 ): Promise<Contribution> => {
   return await changeContributionState({
+    dbClient: args.dbClient,
     contributionId: args.contributionId,
     externalId: args.externalId,
     state: "completed",

--- a/use_cases/completeSubscription.test.ts
+++ b/use_cases/completeSubscription.test.ts
@@ -15,6 +15,7 @@ afterAll(async () => {
 
 test("creates a subscription in the database, completes it and returns it", async () => {
   const resultCreate = await createSubscription({
+    dbClient: prisma,
     email: "emailSub@example.com",
     amountInCents: 100,
   });
@@ -34,6 +35,7 @@ test("creates a subscription in the database, completes it and returns it", asyn
   expect(resultCreate.externalId).toBeNull();
 
   const resultComplete = await completeSubscription({
+    dbClient: prisma,
     subscriptionId: resultCreate.id,
     externalId: "123",
     externalContributionId: "456",
@@ -69,6 +71,7 @@ test("creates a subscription in the database, completes it and returns it", asyn
 
   // if we complete the subscription again, we must not create another contribution
   const resultCancel = await cancelSubscription({
+    dbClient: prisma,
     subscriptionId: resultComplete.id,
   });
   expect(resultCancel.state).toEqual("cancelled");
@@ -82,6 +85,7 @@ test("creates a subscription in the database, completes it and returns it", asyn
   expect(resultCancel.id).toEqual(resultComplete.id);
 
   const resultCompleteAgain = await completeSubscription({
+    dbClient: prisma,
     subscriptionId: resultCancel.id,
     externalId: "123",
     externalContributionId: "456",
@@ -117,6 +121,7 @@ test("creates a subscription in the database, completes it and returns it", asyn
 test("throws error if subscription id is invalid", async () => {
   await expect(
     completeSubscription({
+      dbClient: prisma,
       subscriptionId: -1,
       externalId: "123",
       externalContributionId: "456",
@@ -128,6 +133,7 @@ test("throws error if subscription id does not exist", async () => {
   const id = 99999999;
   await expect(
     completeSubscription({
+      dbClient: prisma,
       subscriptionId: id,
       externalId: "123",
       externalContributionId: "456",

--- a/use_cases/completeSubscription.ts
+++ b/use_cases/completeSubscription.ts
@@ -1,6 +1,7 @@
 import { ContributionSubscription, PrismaClient } from "@prisma/client";
 
 interface CompleteSubscriptionArgs {
+  dbClient: PrismaClient;
   subscriptionId: number;
   externalId: string;
   externalContributionId: string;
@@ -11,7 +12,7 @@ const completeSubscription = async (
 ): Promise<ContributionSubscription> => {
   if (args.subscriptionId <= 0) throw new Error("Invalid id");
 
-  const prisma = new PrismaClient();
+  const prisma = args.dbClient;
 
   const subscription = await prisma.contributionSubscription.findOne({
     where: {

--- a/use_cases/createContribution.test.ts
+++ b/use_cases/createContribution.test.ts
@@ -15,6 +15,7 @@ afterAll(async () => {
 
 test("creates a contribution in the database and returns it", async () => {
   const result = await createContribution({
+    dbClient: prisma,
     email: "email@example.com",
     amountInCents: 100,
   });
@@ -36,11 +37,13 @@ test("creates a contribution in the database and returns it", async () => {
 
 test("creates a contribution for a existing subscription in the database and returns it", async () => {
   const subscription = await createSubscription({
+    dbClient: prisma,
     amountInCents: 123,
     email: "email2@example.com",
   });
 
   const contribution = await createContribution({
+    dbClient: prisma,
     amountInCents: 123,
     subscriptionId: subscription.id,
     externalContributionId: uuidv4(),
@@ -63,19 +66,28 @@ test("creates a contribution for a existing subscription in the database and ret
 
 test("throws error if amount is invalid", async () => {
   await expect(
-    createContribution({ email: "email@example.com", amountInCents: -1 })
+    createContribution({
+      dbClient: prisma,
+      email: "email@example.com",
+      amountInCents: -1,
+    })
   ).rejects.toThrow("Invalid amount");
 });
 
 test("throws error if email is invalid", async () => {
   await expect(
-    createContribution({ email: "not-an-email", amountInCents: 1000 })
+    createContribution({
+      dbClient: prisma,
+      email: "not-an-email",
+      amountInCents: 1000,
+    })
   ).rejects.toThrow("Invalid email");
 });
 
 test("throws error if informing email and subscription", async () => {
   await expect(
     createContribution({
+      dbClient: prisma,
       email: "email@example.com",
       amountInCents: 100,
       subscriptionId: 123,
@@ -86,6 +98,7 @@ test("throws error if informing email and subscription", async () => {
 test("throws error if email and subscription both null", async () => {
   await expect(
     createContribution({
+      dbClient: prisma,
       amountInCents: 100,
     })
   ).rejects.toThrow("Empty email");
@@ -94,6 +107,7 @@ test("throws error if email and subscription both null", async () => {
 test("throws error if subscription not null and external contribution id null", async () => {
   await expect(
     createContribution({
+      dbClient: prisma,
       amountInCents: 100,
       subscriptionId: 1,
     })

--- a/use_cases/createContribution.ts
+++ b/use_cases/createContribution.ts
@@ -1,6 +1,7 @@
 import { Contribution, PrismaClient } from "@prisma/client";
 
 interface CreateContributionArgs {
+  dbClient: PrismaClient;
   email?: string;
   amountInCents: number;
   subscriptionId?: number;
@@ -29,10 +30,8 @@ const createContribution = async (
     );
   }
 
-  const prisma = new PrismaClient();
-
   if (args.subscriptionId) {
-    const existingContribution = await prisma.contribution.findMany({
+    const existingContribution = await args.dbClient.contribution.findMany({
       where: {
         externalId: args.externalContributionId,
       },
@@ -42,7 +41,7 @@ const createContribution = async (
       return existingContribution[0];
     }
 
-    const subscription = await prisma.contributionSubscription.findOne({
+    const subscription = await args.dbClient.contributionSubscription.findOne({
       where: {
         id: args.subscriptionId,
       },
@@ -51,7 +50,7 @@ const createContribution = async (
     if (subscription == null)
       throw new Error(`Subscription Id ${args.subscriptionId} not found`);
 
-    return await prisma.contribution.create({
+    return await args.dbClient.contribution.create({
       data: {
         email: subscription.email,
         amountInCents: args.amountInCents,
@@ -65,7 +64,7 @@ const createContribution = async (
       },
     });
   } else {
-    return await prisma.contribution.create({
+    return await args.dbClient.contribution.create({
       data: {
         email: args.email!,
         amountInCents: args.amountInCents,

--- a/use_cases/createSubscription.test.ts
+++ b/use_cases/createSubscription.test.ts
@@ -13,6 +13,7 @@ afterAll(async () => {
 
 test("creates a subscription in the database and returns it", async () => {
   const result = await createSubscription({
+    dbClient: prisma,
     email: "email@examplesub.com",
     amountInCents: 100,
   });
@@ -30,13 +31,21 @@ test("creates a subscription in the database and returns it", async () => {
 
 test("throws error if amount is invalid", async () => {
   await expect(
-    createSubscription({ email: "email@examplesub.com", amountInCents: -1 })
+    createSubscription({
+      dbClient: prisma,
+      email: "email@examplesub.com",
+      amountInCents: -1,
+    })
   ).rejects.toThrow("Invalid amount");
 });
 
 test("throws error if email is invalid", async () => {
   await expect(
-    createSubscription({ email: "not-an-email", amountInCents: 1000 })
+    createSubscription({
+      dbClient: prisma,
+      email: "not-an-email",
+      amountInCents: 1000,
+    })
   ).rejects.toThrow("Invalid email");
 });
 

--- a/use_cases/createSubscription.ts
+++ b/use_cases/createSubscription.ts
@@ -1,24 +1,24 @@
 import { ContributionSubscription, PrismaClient } from "@prisma/client";
 
 interface CreateSubscriptionArgs {
+  dbClient: PrismaClient;
   email: string;
   amountInCents: number;
 }
 
-const createContribution = async (
+const createSubscription = async (
   args: CreateSubscriptionArgs
 ): Promise<ContributionSubscription> => {
   if (args.amountInCents <= 0) throw new Error("Invalid amount");
   if (args.email.indexOf("@") < 0) throw new Error("Invalid email");
 
-  const prisma = new PrismaClient();
-
-  return await prisma.contributionSubscription.create({
+  return await args.dbClient.contributionSubscription.create({
     data: {
-      ...args,
+      email: args.email,
+      amountInCents: args.amountInCents,
       state: "pending",
     },
   });
 };
 
-export default createContribution;
+export default createSubscription;

--- a/use_cases/getSubscriptionByExternalId.test.ts
+++ b/use_cases/getSubscriptionByExternalId.test.ts
@@ -16,6 +16,7 @@ afterAll(async () => {
 
 test("searches for a subscription by external id", async () => {
   const resultCreated = await createSubscription({
+    dbClient: prisma,
     email: "email@examplesub.com",
     amountInCents: 100,
   });
@@ -26,6 +27,7 @@ test("searches for a subscription by external id", async () => {
   const contributionExternalId = uuidv4();
 
   const resultCompleted = await completeSubscription({
+    dbClient: prisma,
     subscriptionId: resultCreated.id,
     externalId: subscriptionExternalId,
     externalContributionId: contributionExternalId,
@@ -35,6 +37,7 @@ test("searches for a subscription by external id", async () => {
   expect(resultCompleted.state).toEqual("active");
 
   const resultSearch = await getSubscriptionByExternalId({
+    dbClient: prisma,
     externalId: subscriptionExternalId,
   });
 

--- a/use_cases/getSubscriptionByExternalId.ts
+++ b/use_cases/getSubscriptionByExternalId.ts
@@ -1,15 +1,14 @@
 import { ContributionSubscription, PrismaClient } from "@prisma/client";
 
 interface GetSubscriptionByExternalIdArgs {
+  dbClient: PrismaClient;
   externalId: string;
 }
 
 const getSubscriptionByExternalId = async (
   args: GetSubscriptionByExternalIdArgs
 ): Promise<ContributionSubscription | null> => {
-  const prisma = new PrismaClient();
-
-  const subscription = await prisma.contributionSubscription.findMany({
+  const subscription = await args.dbClient.contributionSubscription.findMany({
     where: {
       externalId: args.externalId,
     },


### PR DESCRIPTION
We had several "too many database connections" errors in production environment. The reason is probably because we created a new Prisma Client everytime we used the database, but we never closed the connection.

Now, I am delegating the lifetime management of the Prisma client to the DI container. We will use the Prisma client per scope, and dispose it by the end of the request

Closes #38 