### PR TITLE
fix: have the app not depend on feature flag keys

### DIFF
--- a/services/rox/RoxContainer.js
+++ b/services/rox/RoxContainer.js
@@ -1,12 +1,31 @@
 import { Rox, Flag, Variant } from "rox-ssr";
+
+class FakeFlag {
+  constructor(value) {
+    this.value = value;
+  }
+
+  getValue() {
+    return this.value;
+  }
+}
+
 if (!Rox.containerCache) {
-  Rox.containerCache = {
-    suggestedDonationValues: new Variant("25|75|150", [
-      "25|75|150",
-      "50|150|300",
-      "150|300|500",
-    ]),
-    shouldShowRegistrationForm: new Flag(),
-  };
+  const key = process.env.ROLLOUT_API_KEY || "";
+  if (!key) {
+    Rox.containerCache = {
+      suggestedDonationValues: new FakeFlag("25|75|100"),
+      shouldShowRegistrationForm: new FakeFlag(false),
+    };
+  } else {
+    Rox.containerCache = {
+      suggestedDonationValues: new Variant("25|75|150", [
+        "25|75|150",
+        "50|150|300",
+        "150|300|500",
+      ]),
+      shouldShowRegistrationForm: new Flag(),
+    };
+  }
 }
 export default Rox.containerCache;

--- a/services/rox/RoxService.js
+++ b/services/rox/RoxService.js
@@ -2,8 +2,12 @@ import { Rox } from "rox-ssr";
 export default function (container) {
   if (!Rox.hasStarted) {
     Rox.hasStarted = true;
+
+    const key = process.env.ROLLOUT_API_KEY || "";
+    if (!key) return;
+
     Rox.register("SSR", container);
-    Rox.setup(process.env.ROLLOUT_API_KEY, {
+    Rox.setup(key, {
       version: "1.0.0",
       platform: "Isomorphic",
       configuration:


### PR DESCRIPTION
This will remove the need to have a ROLLOUT_API_KEY (which is unnecessary for dev env).