### PR TITLE
chore: automatic migrations on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,6 @@ jobs:
     - name: Run Typescript typechecking
       run: npm run typecheck
     - name: Setup database
-      run: npx prisma migrate deploy --preview-feature
+      run: npm run migrate-deploy
     - name: Run Tests
       run: npm test -- --detectOpenHandles --forceExit

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+release: npm run migrate-deploy
+web: npm start

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cp prisma/.env.example prisma/.env
 After making sure Postgresql is running, run the migrations to configure the database
 
 ```bash
-npx prisma migrate dev --preview-feature
+npm run migrate-dev
 ```
 
 ### Setup other variables

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "heroku-postbuild": "npm run build",
     "test": "jest --runInBand",
     "lint": "eslint '*/**/*.{js,ts,tsx}'",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "migrate-deploy": "prisma migrate deploy --preview-feature",
+    "migrate-dev": "prisma migrate dev --preview-feature"
   },
   "dependencies": {
     "@material-ui/core": "^4.11.2",


### PR DESCRIPTION
Esse PR adiciona migrações ao heroku automaticamente.
Também adiciona comandos `npm run migrate-dev` e `npm run migrate-deploy` para remover a necessidade de usar `npx prisma migrate dev|deploy --preview-feature` que era mais verboso e precisava usar o `npx`.

Dessa maneira, quando a feature deixar de ser preview no prisma bastará mudar o `package.json` e o resto estará provavelmente normal (assumindo que não vai mudar muita coisa do preview para o stable).

Pra fazer isso acontecer automaticamente no heroku, eu adicionei um Procfile.