### PR TITLE
fix: page scroll

### DIFF
--- a/components/Form.module.css
+++ b/components/Form.module.css
@@ -13,6 +13,10 @@
     font-size: 15px;
 }
 
+.donationModeWrapper {
+    position: relative;
+}
+
 .donationModeWrapper .outlinedButton {
     width: 100%;
     height: 100%;
@@ -22,6 +26,17 @@
     text-transform: none;   
     font-size: 15px;
 }
+
+.donationValues .defaultValues {
+    margin-bottom: 20px;
+    display: flex;
+    justify-content: space-between;
+}
+
+.donationValues p {
+    margin: 30px auto 15px auto;
+}
+
 
 .navigationSteps {
     margin-bottom: 28px;
@@ -41,25 +56,27 @@
 
 }
 
-.donationModeWrapper {
-    position: relative;
-}
-
-.donationValues .defaultValues {
-    margin-bottom: 20px;
-    display: flex;
-    justify-content: space-between;
-}
-
-.donationValues p {
-    margin: 30px auto 15px auto;
-}
-
 .title {
     margin: 35px 0 15px 0;
 }
 
 /*Checkbox code styles*/
+
+.checkbox {
+    margin-bottom: -10px;
+}
+
+.checkbox:checked~.section .container .row .col-12 .defaultValues__value:not(:checked)+label {
+    background-color: var(--light);
+    color: var(--dark-blue);
+    box-shadow: 0 1x 4px 0 rgba(0, 0, 0, 0.05);
+}
+
+.checkboxGroup {
+    margin-top: 0px;
+    display: flex;
+    flex-direction: column;
+}
 
 .defaultValues__value {
     border: 2px solid #00d4ff;
@@ -119,12 +136,6 @@
      z-index: -1;
 }
 
-.checkbox:checked~.section .container .row .col-12 .defaultValues__value:not(:checked)+label {
-    background-color: var(--light);
-    color: var(--dark-blue);
-    box-shadow: 0 1x 4px 0 rgba(0, 0, 0, 0.05);
-}
-
 .modalUserRegistration {
     z-index: 2;
     margin-left: -20px;
@@ -139,12 +150,5 @@
     margin-top: 20px !important;
 }
 
-.checkboxGroup {
-    margin-top: 0px;
-    display: flex;
-    flex-direction: column;
-}
 
-.checkbox {
-    margin-bottom: -10px;
-}
+

--- a/pages/index.module.css
+++ b/pages/index.module.css
@@ -1,7 +1,3 @@
-.__next{
-  background-color: aqua;
-}
-
 .main {
   height: 100vh;
   display: flex;

--- a/pages/index.module.css
+++ b/pages/index.module.css
@@ -1,3 +1,35 @@
+.main {
+  height: 100vh;
+  display: flex;
+}
+
+@media (min-resolution: 2dppx) {
+  .main {
+    height: 125vh !important;
+  }
+}
+
+
+.rightSide {
+  color: white;
+  background-image: url("/loginBkg.png");
+  background-size: cover;
+  background-repeat: no-repeat;
+  height: 100%;
+  width: 100%;
+  padding: 50px 32%;
+  display: flex !important;
+  flex-direction: column;
+  justify-content: start;
+  align-items: start;
+  /* vertical-align: middle; */
+  overflow-y: auto;
+  text-align: start;
+  overflow-x: none;
+}
+
+
+
 .rightSide input:focus {
   color: var(--mdc-theme-primary) !important;
 }
@@ -12,41 +44,6 @@
   margin: 1px auto 6px -1rem;
 }
 
-@media not all and (min-resolution:.001dpcm) {
-  @media {
-    .rightSide label span {
-      margin: 1px auto 6px -.8rem;
-    }
-  }
-}
-
-.rightSide {
-  color: white;
-  background-image: url("/loginBkg.png");
-  background-size: cover;
-  background-repeat: no-repeat;
-  height: 125vh;
-  padding: 10px 32%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  vertical-align: middle;
-}
-
-
-@media not all and (min-resolution:.001dpcm) { 
-  @supports (-webkit-appearance:none) {
-    .rightSide {
-      height: 100vh;
-    }
-  }
-}
-
-@-moz-document url-prefix() {
-  .rightSide {
-    height: 100vh;
-  }
-}  
 
 .rightSide img {
   width: 100px;
@@ -59,54 +56,17 @@
 }
 
 
+
 .leftSide {
-  padding: 10px 15%;
+  width: 50%;
+  padding: 10px 20px;
   display: flex;
+  height: 100%;
   flex-direction: column;
+  align-items: start;
   justify-content: center;
-  vertical-align: middle;
-}
-
-@media only screen and (max-width: 800px) {
-  .leftSide {
-    display: none;
-  }
-
-  .rightSide {
-    display: flow-root;
-    padding: 12rem 10%;
-    overflow: auto;
-  }
-
-  .leftSide ul li {
-    height: 5.5rem;
-    margin-bottom: 2rem;
-  }
-}
-
-@media only screen and (max-height: 375px) {
-  .leftSide {
-    display: none;
-  }
-  .rightSide {
-    overflow: auto;
-  }
-}
-
-@media only screen and (max-height: 800px) {
-  .leftSide {
-    padding: 10px 15%;
-  }
-
-  .leftSide ul li {
-    height: 5.5rem;
-    margin-bottom: 2rem;
-  }
-
-  .rightSide {
-    padding: 10px 10%;
-    display: flow-root;
-  }
+  text-align: left;
+  overflow-y: auto;
 }
 
 .leftSide p {
@@ -125,8 +85,7 @@
 
 .leftSide ul li {
   font-family: 'Open sans' sans-serif;
-
-  height: 2.5rem;
+  /* height: 2.5rem; */
   margin-bottom: 2rem;
 }
 
@@ -136,4 +95,68 @@
 
 .navigationSteps {
   display: flex;
+}
+
+
+
+@media not all and (min-resolution:.001dpcm) {
+  @media {
+    .rightSide label span {
+      margin: 1px auto 6px -.8rem;
+    }
+  }
+}
+
+@media not all and (min-resolution:.001dpcm) { 
+  @supports (-webkit-appearance:none) {
+    .rightSide {
+      height: 100%;
+    }
+  }
+}
+
+@-moz-document url-prefix() {
+  .rightSide {
+    height: 100%;
+  }
+}  
+
+
+@media only screen and (max-width: 800px) {
+  .leftSide {
+    display: none;
+  }
+
+  .rightSide {
+    display: flow-root;
+    padding: 12rem 10%;
+  }
+
+  .leftSide ul li {
+    /* height: 5.5rem; */
+    margin-bottom: 2rem;
+  }
+}
+
+@media only screen and (max-height: 375px) {
+  .leftSide {
+    display: none;
+  }
+}
+
+@media only screen and (max-height: 800px) {
+  .leftSide {
+    padding: 10px 5%;
+  }
+
+  .leftSide ul li {
+    height: auto !important;
+    margin-bottom: 2rem;
+  }
+
+  .rightSide {
+    padding: 50px 10%;
+    padding-bottom: 100px;
+    display: flow-root;
+  }
 }

--- a/pages/index.module.css
+++ b/pages/index.module.css
@@ -1,3 +1,7 @@
+.__next{
+  background-color: aqua;
+}
+
 .main {
   height: 100vh;
   display: flex;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -23,9 +23,8 @@ export default function Home() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <main>
-        <GridRow>
-          <GridCell
+      <main class={styles.main}>
+          <div
             order={0}
             className={styles.leftSide}
             desktop={4}
@@ -49,8 +48,8 @@ export default function Home() {
                 text="perpetua uma cultura de retribuição"
               />
             </List>
-          </GridCell>
-          <GridCell
+          </div>
+          <div
             order={1}
             className={styles.rightSide}
             desktop={8}
@@ -60,8 +59,7 @@ export default function Home() {
           >
             <img src="./logoReditusWhite.png" />
             <Form />
-          </GridCell>
-        </GridRow>
+          </div>
       </main>
     </div>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,4 @@
 import Head from "next/head";
-import { GridRow, GridCell } from "@rmwc/grid";
 import { List, SimpleListItem } from "@rmwc/list";
 import styles from "./index.module.css";
 
@@ -23,43 +22,38 @@ export default function Home() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <main class={styles.main}>
-          <div
-            order={0}
-            className={styles.leftSide}
-            desktop={4}
-            align={"middle"}
-          >
-            <p>Tornando-se parte dessa iniciativa você...</p>
-            <List nonInteractive={true}>
-              <SimpleListItem
-                ripple={false}
-                graphic="radio_button_checked"
-                text="retorna um bem à comunidade de alunos e ex-alunos da UFRJ"
-              />
-              <SimpleListItem
-                ripple={false}
-                graphic="radio_button_checked"
-                text="ajuda a fomentar uma estrutura de auxílio a alunos e equipes de competição"
-              />
-              <SimpleListItem
-                ripple={false}
-                graphic="radio_button_checked"
-                text="perpetua uma cultura de retribuição"
-              />
-            </List>
-          </div>
-          <div
-            order={1}
-            className={styles.rightSide}
-            desktop={8}
-            tablet={12}
-            phone={12}
-            align={"middle"}
-          >
-            <img src="./logoReditusWhite.png" />
-            <Form />
-          </div>
+      <main className={styles.main}>
+        <div order={0} className={styles.leftSide} desktop={4} align={"middle"}>
+          <p>Tornando-se parte dessa iniciativa você...</p>
+          <List nonInteractive={true}>
+            <SimpleListItem
+              ripple={false}
+              graphic="radio_button_checked"
+              text="retorna um bem à comunidade de alunos e ex-alunos da UFRJ"
+            />
+            <SimpleListItem
+              ripple={false}
+              graphic="radio_button_checked"
+              text="ajuda a fomentar uma estrutura de auxílio a alunos e equipes de competição"
+            />
+            <SimpleListItem
+              ripple={false}
+              graphic="radio_button_checked"
+              text="perpetua uma cultura de retribuição"
+            />
+          </List>
+        </div>
+        <div
+          order={1}
+          className={styles.rightSide}
+          desktop={8}
+          tablet={12}
+          phone={12}
+          align={"middle"}
+        >
+          <img src="./logoReditusWhite.png" />
+          <Form />
+        </div>
       </main>
     </div>
   );


### PR DESCRIPTION
Impactos
- É possível rolar a página de entrada quando o conteúdo da direita/esquerda ultrapassa a tela no browser do PC.
- Conteúdo da direita está centralizado.
- Quando há redução vertical da tela e a caixa da esquerda some, a caixa da direita se extende.

Notas
- A maior parte das mudanças foram de .css, mas o PR troca o uso do @rmwc/grid por uma estrutura de flexbox simples, mais fácil de lapidar.

O gif abaixo mostra a diferença entre o antes e dps das mudanças do PR.

![Recording 2022-09-22 at 19 27 05](https://user-images.githubusercontent.com/15219345/191862241-da31c77f-3df4-4cdb-87fe-dc93cabc9689.gif)

